### PR TITLE
Use CXX as the C++ compiler to build HHVM examples

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -589,7 +589,7 @@ hhvm: $(SRCDIR_SRCS)
 	@hphpize
 	@mkdir build
 	cd build && \
-	cmake .. && \
+	cmake .. -DCMAKE_CXX_COMPILER='$(CXX)' && \
 	$(MAKE) && \
 	mv $(LIBPREFIX)$(TARGET)$(HHVM_SO) ..
 	#$(CC) -c $(CCSHARED) $(CPPFLAGS) $(CFLAGS) $(SRCDIR_SRCS) $(ISRCS) $(INCLUDES) $(HHVM_INCLUDE)
@@ -604,7 +604,7 @@ hhvm_cpp: $(SRCDIR_SRCS)
 	@hphpize
 	@mkdir build
 	cd build && \
-	cmake .. && \
+	cmake .. -DCMAKE_CXX_COMPILER='$(CXX)' && \
 	$(MAKE) && \
 	mv $(LIBPREFIX)$(TARGET)$(HHVM_SO) ..
 	#$(CXX) -c $(CCSHARED) $(CPPFLAGS) $(CXXFLAGS) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS) $(ICXXSRCS) $(INCLUDES) $(HHVM_INCLUDE)


### PR DESCRIPTION
HHVM doesn't currently work with GCC 6.1.1 and this provides a simple
way to specify a different compiler.
